### PR TITLE
Updated MVAMETPairProducer for CMSSW 72X

### DIFF
--- a/plugins/BuildFile.xml
+++ b/plugins/BuildFile.xml
@@ -1,5 +1,5 @@
 <library file="*.cc" name="ICAnalysisMVAMETPairProducerplugins">
-  <use name="JetMETCorrections/METPUSubtraction"/>
+  <use name="RecoMET/METPUSubtraction"/>
   <use name="clhep"/>
   <flags EDM_PLUGIN="1"/>
   <flags CPPDEFINES="$(CMSSW_VERSION)"/>

--- a/plugins/MVAMETPairProducer.hh
+++ b/plugins/MVAMETPairProducer.hh
@@ -29,8 +29,8 @@
 
 #include "RecoMET/METAlgorithms/interface/METAlgo.h"
 #include "RecoMET/METAlgorithms/interface/PFSpecificAlgo.h"
-#include "JetMETCorrections/METPUSubtraction/interface/PFMETAlgorithmMVA.h"
-#include "JetMETCorrections/METPUSubtraction/interface/mvaMEtUtilities.h"
+#include "RecoMET/METPUSubtraction/interface/PFMETAlgorithmMVA.h"
+#include "RecoMET/METPUSubtraction/interface/mvaMEtUtilities.h"
 
 #include "RecoJets/JetProducers/interface/PileupJetIdAlgo.h"
 
@@ -50,11 +50,11 @@ namespace reco
     void produce(edm::Event&, const edm::EventSetup&);
 
     // auxiliary functions
-    std::vector<mvaMEtUtilities::JetInfo> computeJetInfo(const reco::PFJetCollection&, const reco::PFJetCollection&, const reco::VertexCollection&, const reco::Vertex*, 
+    std::vector<reco::PUSubMETCandInfo> computeJetInfo(const reco::PFJetCollection&, const reco::PFJetCollection&, const reco::VertexCollection&, const reco::Vertex*, 
                              const JetCorrector &iCorr,edm::Event & iEvent,const edm::EventSetup &iSetup,
-                             std::vector<mvaMEtUtilities::leptonInfo> &iLeptons,std::vector<mvaMEtUtilities::pfCandInfo> &iCands);
+                             std::vector<reco::PUSubMETCandInfo> &iLeptons,std::vector<reco::PUSubMETCandInfo> &iCands);
     
-    std::vector<mvaMEtUtilities::pfCandInfo> computePFCandidateInfo(const reco::PFCandidateCollection&, const reco::Vertex*);
+    std::vector<reco::PUSubMETCandInfo> computePFCandidateInfo(const reco::CandidateView&, const reco::Vertex*);
     std::vector<reco::Vertex::Point> computeVertexInfo(const reco::VertexCollection&);
     double chargedFrac(const reco::Candidate *iCand,const reco::PFCandidateCollection& pfCandidates,const reco::Vertex* hardScatterVertex);
     
@@ -89,6 +89,7 @@ namespace reco
     METAlgo metAlgo_;
     PFSpecificAlgo pfMEtSpecificAlgo_;
     PFMETAlgorithmMVA mvaMEtAlgo_;
+    bool mvaMEtAlgo_isInitialized_; 
     PileupJetIdAlgo mvaJetIdAlgo_;
 
     int verbosity_;

--- a/plugins/MVAMETPairProducer.hh
+++ b/plugins/MVAMETPairProducer.hh
@@ -56,11 +56,11 @@ namespace reco
     
     std::vector<reco::PUSubMETCandInfo> computePFCandidateInfo(const reco::CandidateView&, const reco::Vertex*);
     std::vector<reco::Vertex::Point> computeVertexInfo(const reco::VertexCollection&);
-    double chargedFrac(const reco::Candidate *iCand,const reco::PFCandidateCollection& pfCandidates,const reco::Vertex* hardScatterVertex);
+    double chargedEnFrac(const reco::Candidate *iCand,const reco::CandidateView& pfCandidates,const reco::Vertex* hardScatterVertex);
     
     bool   passPFLooseId(const reco::PFJet *iJet);
     bool   istau        (const reco::Candidate *iCand);
-    double chargedFracInCone(const reco::Candidate *iCand,const reco::PFCandidateCollection& pfCandidates,const reco::Vertex* hardScatterVertex,double iDRMax=0.2);
+    double chargedFracInCone(const reco::Candidate *iCand,const reco::CandidateView& pfCandidates,const reco::Vertex* hardScatterVertex,double iDRMax=0.2);
 
    // configuration parameter
     edm::InputTag srcCorrJets_;

--- a/python/mvaPFMET_cff_leptons_72X.py
+++ b/python/mvaPFMET_cff_leptons_72X.py
@@ -1,0 +1,70 @@
+import FWCore.ParameterSet.Config as cms
+
+from JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff  import *
+from JetMETCorrections.Configuration.DefaultJEC_cff             import *
+from RecoMET.METPUSubtraction.mvaPFMET_cff    import *
+#del hpsPFTauDiscriminationByDecayModeFinding
+from RecoJets.JetProducers.PileupJetIDParams_cfi                import JetIdParams
+
+mvaMetPairs = cms.EDProducer("MVAMETPairProducer",
+    srcCorrJets = cms.InputTag('calibratedAK4PFJetsForPFMVAMEt'),
+    srcUncorrJets = cms.InputTag('ak4PFJets'),
+    srcPFCandidates = cms.InputTag('particleFlow'),
+    srcVertices = cms.InputTag('offlinePrimaryVertices'),
+    srcLeg1 = cms.InputTag('dummyCollection'),
+    srcLeg2 = cms.InputTag('dummyCollection'),
+    leg1Pt = cms.double(10.0),
+    leg1Eta = cms.double(2.6),
+    leg2Pt = cms.double(10.0),
+    leg2Eta = cms.double(2.6),
+    minDeltaR = cms.double(0.3),
+#    srcRho = cms.InputTag('kt6PFJets','rho'),
+    srcRho = cms.InputTag("fixedGridRhoFastjetAll"),
+    globalThreshold = cms.double(-1.),#pfMet.globalThreshold,
+    minCorrJetPt = cms.double(-1.),
+    inputFileNames = cms.PSet(
+        U     = cms.FileInPath('RecoMET/METPUSubtraction/data/gbrmet_7_2_X_MINIAOD_BX25PU20_Mar2015.root'),
+        DPhi  = cms.FileInPath('RecoMET/METPUSubtraction/data/gbrphi_7_2_X_MINIAOD_BX25PU20_Mar2015.root'),
+        CovU1 = cms.FileInPath('RecoMET/METPUSubtraction/data/gbru1cov_7_2_X_MINIAOD_BX25PU20_Mar2015.root'),
+        CovU2 = cms.FileInPath('RecoMET/METPUSubtraction/data/gbru2cov_7_2_X_MINIAOD_BX25PU20_Mar2015.root')
+    ),
+    inputRecords = cms.PSet(
+        U     = cms.string("RecoilCor"),
+        DPhi  = cms.string("PhiCor"), 
+        CovU1 = cms.string("CovU1"),
+        CovU2 = cms.string("CovU2")
+    ),
+    loadMVAfromDB = cms.bool(False),
+    corrector = cms.string("ak4PFL1Fastjet"),
+    useType1  = cms.bool(False),
+    useOld42  = cms.bool(False),
+    dZcut = cms.double(0.1),
+    impactParTkThreshold = cms.double(0.),
+    tmvaWeights = cms.string("RecoJets/JetProducers/data/TMVAClassificationCategory_JetID_MET_53X_Dec2012.weights.xml.gz"),
+    tmvaMethod = cms.string("JetID"),
+    version = cms.int32(-1),
+    cutBased = cms.bool(False),
+    tmvaVariables = cms.vstring(
+        "nvtx",
+        "jetPt",
+        "jetEta",
+        "jetPhi",
+        "dZ",
+        "beta",
+        "betaStar",
+        "nCharged",
+        "nNeutrals",
+        "dR2Mean",
+        "ptD",
+        "frac01",
+        "frac02",
+        "frac03",
+        "frac04",
+        "frac05",
+    ),
+    tmvaSpectators = cms.vstring(),
+    JetIdParams = JetIdParams,
+    label = cms.string("full"),
+    verbosity = cms.int32(0)
+)
+


### PR DESCRIPTION
The MVAMETPairProducer now runs on both aod and miniaod in cmssw 72X. The # of changes is large because this plugin mainly uses the same/similar functions as the base MVAMET code (in RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc), which has changed a lot since CMSSW 53X.